### PR TITLE
feat(camera): Add Camera component with transform-driven view and projection

### DIFF
--- a/engine/include/vroom/components/Camera.hpp
+++ b/engine/include/vroom/components/Camera.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "vroom/core/Component.hpp"
+#include <glm/glm.hpp>
+#include <memory>
+
+namespace vroom {
+
+/// \brief Projection type for the camera.
+enum class ProjectionType {
+    Perspective,
+    Orthographic
+};
+
+/// \brief Normalized viewport rectangle (values in [0,1] range).
+struct ViewportRect {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 1.0f;
+    float height = 1.0f;
+};
+
+/// \brief Camera component that defines how the scene is rendered.
+///
+/// Works in tandem with the Transform component to compute view and projection matrices.
+/// Modeled after Unity's Camera component. Supports perspective and orthographic projection,
+/// viewport rectangles, clear color, and depth-based ordering for multiple cameras.
+/// The targetTexture field is reserved for future RenderTexture support.
+class Camera : public Component {
+public:
+    Camera() = default;
+    ~Camera() override = default;
+
+    // -- Projection type --
+
+    /// \brief Gets the projection type.
+    [[nodiscard]] ProjectionType getProjectionType() const { return m_projectionType; }
+
+    /// \brief Sets the projection type.
+    void setProjectionType(ProjectionType type) { m_projectionType = type; }
+
+    // -- Field of view (perspective only) --
+
+    /// \brief Gets the vertical field of view in degrees.
+    [[nodiscard]] float getFieldOfView() const { return m_fieldOfView; }
+
+    /// \brief Sets the vertical field of view in degrees.
+    void setFieldOfView(float fov) { m_fieldOfView = fov; }
+
+    // -- Orthographic size --
+
+    /// \brief Gets the orthographic half-height.
+    [[nodiscard]] float getOrthographicSize() const { return m_orthographicSize; }
+
+    /// \brief Sets the orthographic half-height.
+    void setOrthographicSize(float size) { m_orthographicSize = size; }
+
+    // -- Clip planes --
+
+    /// \brief Gets the near clip plane distance.
+    [[nodiscard]] float getNearClipPlane() const { return m_nearClipPlane; }
+
+    /// \brief Sets the near clip plane distance.
+    void setNearClipPlane(float near) { m_nearClipPlane = near; }
+
+    /// \brief Gets the far clip plane distance.
+    [[nodiscard]] float getFarClipPlane() const { return m_farClipPlane; }
+
+    /// \brief Sets the far clip plane distance.
+    void setFarClipPlane(float far) { m_farClipPlane = far; }
+
+    // -- Background color --
+
+    /// \brief Gets the background (clear) color.
+    [[nodiscard]] const glm::vec4& getBackgroundColor() const { return m_backgroundColor; }
+
+    /// \brief Sets the background (clear) color.
+    void setBackgroundColor(const glm::vec4& color) { m_backgroundColor = color; }
+
+    // -- Depth (rendering priority) --
+
+    /// \brief Gets the camera depth (rendering priority). Lower renders first.
+    [[nodiscard]] int getDepth() const { return m_depth; }
+
+    /// \brief Sets the camera depth (rendering priority).
+    void setDepth(int depth) { m_depth = depth; }
+
+    // -- Viewport rect --
+
+    /// \brief Gets the normalized viewport rectangle.
+    [[nodiscard]] const ViewportRect& getViewportRect() const { return m_viewportRect; }
+
+    /// \brief Sets the normalized viewport rectangle.
+    void setViewportRect(const ViewportRect& rect) { m_viewportRect = rect; }
+
+    // -- Target texture (placeholder for future RenderTexture) --
+
+    /// \brief Gets the render target texture. nullptr means render to screen.
+    [[nodiscard]] std::shared_ptr<void> getTargetTexture() const { return m_targetTexture; }
+
+    /// \brief Sets the render target texture. Pass nullptr to render to screen.
+    void setTargetTexture(std::shared_ptr<void> texture) { m_targetTexture = std::move(texture); }
+
+    /// \brief Returns true if this camera renders to screen (no target texture).
+    [[nodiscard]] bool rendersToScreen() const { return m_targetTexture == nullptr; }
+
+    // -- Matrix computation --
+
+    /// \brief Computes the view matrix from the entity's Transform.
+    /// \return The view matrix (world-to-camera transform).
+    [[nodiscard]] glm::mat4 getViewMatrix() const;
+
+    /// \brief Computes the projection matrix.
+    /// \param aspectRatio The viewport aspect ratio (width / height).
+    /// \return The projection matrix.
+    [[nodiscard]] glm::mat4 getProjectionMatrix(float aspectRatio) const;
+
+    /// \brief Computes the combined view-projection matrix.
+    /// \param aspectRatio The viewport aspect ratio (width / height).
+    /// \return The view-projection matrix (projection * view).
+    [[nodiscard]] glm::mat4 getViewProjectionMatrix(float aspectRatio) const;
+
+    // -- Static helpers --
+
+    /// \brief Finds the main camera in the given scene.
+    /// Returns the enabled Camera with the lowest depth value,
+    /// or nullptr if no camera exists.
+    /// \param scene The scene to search.
+    /// \return Pointer to the main camera, or nullptr.
+    static Camera* getMain(class Scene& scene);
+
+private:
+    ProjectionType m_projectionType = ProjectionType::Perspective;
+    float m_fieldOfView = 60.0f;
+    float m_orthographicSize = 5.0f;
+    float m_nearClipPlane = 0.1f;
+    float m_farClipPlane = 1000.0f;
+    glm::vec4 m_backgroundColor{0.192f, 0.302f, 0.475f, 1.0f};
+    int m_depth = 0;
+    ViewportRect m_viewportRect{};
+    std::shared_ptr<void> m_targetTexture = nullptr;
+};
+
+} // namespace vroom

--- a/engine/shaders/shader.vert
+++ b/engine/shaders/shader.vert
@@ -7,30 +7,12 @@ layout(location = 2) in vec2 inTexCoord;
 layout(location = 0) out vec3 fragColor;
 
 layout(push_constant) uniform PushConstants {
+    mat4 viewProjection;
     mat4 model;
 } push;
 
 void main() {
-    vec4 worldPos = push.model * vec4(inPosition, 1.0);
-
-    // Simple view matrix: move camera back along Z
-    vec3 viewPos = worldPos.xyz - vec3(0.0, 0.0, 3.0);
-
-    // Simple perspective projection
-    float fov = 1.0;
-    float aspect = 800.0 / 600.0;
-    float near = 0.1;
-    float far = 100.0;
-
-    float f = 1.0 / tan(fov / 2.0);
-    mat4 projection = mat4(
-        f / aspect, 0.0, 0.0, 0.0,
-        0.0, f, 0.0, 0.0,
-        0.0, 0.0, (far + near) / (near - far), -1.0,
-        0.0, 0.0, (2.0 * far * near) / (near - far), 0.0
-    );
-
-    gl_Position = projection * vec4(viewPos, 1.0);
+    gl_Position = push.viewProjection * push.model * vec4(inPosition, 1.0);
 
     // Debug color based on normal
     fragColor = inNormal * 0.5 + 0.5;

--- a/engine/src/asset/ObjLoader.cpp
+++ b/engine/src/asset/ObjLoader.cpp
@@ -9,7 +9,7 @@ namespace vroom {
 static void parsePosition(std::stringstream& lineSS, std::vector<glm::vec3>& positions) {
     glm::vec3 pos;
     lineSS >> pos.x >> pos.y >> pos.z;
-    pos.y = -pos.y;
+
     positions.push_back(pos);
 }
 

--- a/engine/src/components/Camera.cpp
+++ b/engine/src/components/Camera.cpp
@@ -1,0 +1,71 @@
+#include "vroom/components/Camera.hpp"
+#include "vroom/components/Transform.hpp"
+#include "vroom/core/Entity.hpp"
+#include "vroom/core/Scene.hpp"
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/ext/matrix_clip_space.hpp>
+
+namespace vroom {
+
+static void findCameraRecursive(Entity* entity, Camera*& best) {
+    if (!entity || !entity->isActive()) return;
+    auto* cam = entity->getComponent<Camera>();
+    if (cam && cam->isEnabled()) {
+        if (!best || cam->getDepth() < best->getDepth()) {
+            best = cam;
+        }
+    }
+    for (auto* child : entity->getChildren()) {
+        findCameraRecursive(child, best);
+    }
+}
+
+glm::mat4 Camera::getViewMatrix() const {
+    if (!m_entity) {
+        return glm::mat4(1.0f);
+    }
+    auto* transform = m_entity->getComponent<Transform>();
+    if (!transform) {
+        return glm::mat4(1.0f);
+    }
+    // The view matrix is the inverse of the camera's world transform.
+    return transform->worldToLocalMatrix();
+}
+
+glm::mat4 Camera::getProjectionMatrix(float aspectRatio) const {
+    if (m_projectionType == ProjectionType::Perspective) {
+        // perspectiveRH_ZO maps near→0, far→1 matching Vulkan's [0,1] depth range.
+        // Y is flipped to convert from OpenGL's Y-up NDC to Vulkan's Y-down NDC.
+        glm::mat4 proj = glm::perspectiveRH_ZO(
+            glm::radians(m_fieldOfView),
+            aspectRatio,
+            m_nearClipPlane,
+            m_farClipPlane
+        );
+        proj[1][1] *= -1.0f;
+        return proj;
+    }
+    float halfHeight = m_orthographicSize;
+    float halfWidth = halfHeight * aspectRatio;
+    glm::mat4 proj = glm::orthoRH_ZO(
+        -halfWidth, halfWidth,
+        -halfHeight, halfHeight,
+        m_nearClipPlane, m_farClipPlane
+    );
+    proj[1][1] *= -1.0f;
+    return proj;
+}
+
+glm::mat4 Camera::getViewProjectionMatrix(float aspectRatio) const {
+    return getProjectionMatrix(aspectRatio) * getViewMatrix();
+}
+
+Camera* Camera::getMain(Scene& scene) {
+    Camera* best = nullptr;
+    for (auto* root : scene.getRootEntities()) {
+        findCameraRecursive(root, best);
+    }
+    return best;
+}
+
+} // namespace vroom

--- a/engine/src/components/MeshRenderer.cpp
+++ b/engine/src/components/MeshRenderer.cpp
@@ -37,7 +37,9 @@ static void pushModelMatrix(VkCommandBuffer commandBuffer, const glm::mat4& mode
     auto renderer = engine ? engine->getRenderer() : nullptr;
     if (renderer) {
         VkPipelineLayout layout = renderer->getPipelineLayout();
-        vkCmdPushConstants(reinterpret_cast<::VkCommandBuffer>(commandBuffer), layout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::mat4), &model);
+        // Model matrix sits after the viewProjection matrix in push constants.
+        constexpr uint32_t MODEL_OFFSET = sizeof(glm::mat4);
+        vkCmdPushConstants(reinterpret_cast<::VkCommandBuffer>(commandBuffer), layout, VK_SHADER_STAGE_VERTEX_BIT, MODEL_OFFSET, sizeof(glm::mat4), &model);
     }
 }
 

--- a/engine/src/vulkan/VulkanRenderer.cpp
+++ b/engine/src/vulkan/VulkanRenderer.cpp
@@ -2,6 +2,7 @@
 #include "vroom/logging/LogMacros.hpp"
 #include "vroom/asset/ShaderAsset.hpp"
 #include "vroom/core/Scene.hpp"
+#include "vroom/components/Camera.hpp"
 #include "vroom/asset/Mesh.hpp"
 #include "vroom/vulkan/VulkanMeshData.hpp"
 #include "vroom/vulkan/VulkanBuffer.hpp"
@@ -253,7 +254,7 @@ VkPipelineVertexInputStateCreateInfo VulkanRenderer::createVertexInputState(VkVe
 VkPipelineLayoutCreateInfo VulkanRenderer::createPipelineLayoutInfo(VkPushConstantRange& pushConstantRange) {
     pushConstantRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     pushConstantRange.offset = 0;
-    pushConstantRange.size = sizeof(glm::mat4);
+    pushConstantRange.size = 2 * sizeof(glm::mat4); // viewProjection + model
     VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
     pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     pipelineLayoutInfo.setLayoutCount = 0;
@@ -420,20 +421,31 @@ void VulkanRenderer::recordCommandBuffer(VkCommandBuffer commandBuffer, uint32_t
 
         vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, m_graphicsPipeline);
 
+        VkExtent2D extent = m_swapChain->getSwapChainExtent();
         VkViewport viewport{};
         viewport.x = 0.0f;
         viewport.y = 0.0f;
-        viewport.width = (float) m_swapChain->getSwapChainExtent().width;
-        viewport.height = (float) m_swapChain->getSwapChainExtent().height;
+        viewport.width = static_cast<float>(extent.width);
+        viewport.height = static_cast<float>(extent.height);
         viewport.minDepth = 0.0f;
         viewport.maxDepth = 1.0f;
         vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
-
         VkRect2D scissor{};
         scissor.offset = {0, 0};
-        scissor.extent = m_swapChain->getSwapChainExtent();
+        scissor.extent = extent;
         vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
-
+        // Compute and push the view-projection matrix from the scene camera.
+        glm::mat4 viewProjection(1.0f);
+        if (scene) {
+            Camera* camera = Camera::getMain(*scene);
+            if (camera) {
+                float aspectRatio = (extent.height > 0)
+                    ? static_cast<float>(extent.width) / static_cast<float>(extent.height)
+                    : 1.0f;
+                viewProjection = camera->getViewProjectionMatrix(aspectRatio);
+            }
+        }
+        vkCmdPushConstants(commandBuffer, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::mat4), &viewProjection);
         if (scene) {
             scene->draw(commandBuffer);
         } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(core_tests
     core/MeshTest.cpp
     core/DrawingTest.cpp
     components/TransformTest.cpp
+    components/CameraTest.cpp
 )
 
 target_link_libraries(core_tests

--- a/tests/components/CameraTest.cpp
+++ b/tests/components/CameraTest.cpp
@@ -1,0 +1,277 @@
+#include <gtest/gtest.h>
+#include <glm/gtc/epsilon.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/ext/matrix_clip_space.hpp>
+#include "vroom/components/Camera.hpp"
+#include "vroom/components/Transform.hpp"
+#include "vroom/core/Entity.hpp"
+#include "vroom/core/Scene.hpp"
+#include "vroom/core/SceneManager.hpp"
+
+using namespace vroom;
+
+class CameraTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sceneManager = std::make_shared<SceneManager>();
+        scene = std::make_shared<Scene>();
+        scene->setSceneManager(sceneManager.get());
+    }
+
+    std::shared_ptr<SceneManager> sceneManager;
+    std::shared_ptr<Scene> scene;
+
+    bool vec3Eq(const glm::vec3& v1, const glm::vec3& v2, float epsilon = 0.0001f) {
+        return glm::all(glm::epsilonEqual(v1, v2, epsilon));
+    }
+
+    bool mat4Eq(const glm::mat4& m1, const glm::mat4& m2, float epsilon = 0.0001f) {
+        for (int i = 0; i < 4; ++i) {
+            if (!glm::all(glm::epsilonEqual(m1[i], m2[i], epsilon))) return false;
+        }
+        return true;
+    }
+};
+
+// -- Default values --
+
+TEST_F(CameraTest, DefaultProjectionType) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_EQ(cam.getProjectionType(), ProjectionType::Perspective);
+}
+
+TEST_F(CameraTest, DefaultFieldOfView) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_FLOAT_EQ(cam.getFieldOfView(), 60.0f);
+}
+
+TEST_F(CameraTest, DefaultClipPlanes) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_FLOAT_EQ(cam.getNearClipPlane(), 0.1f);
+    EXPECT_FLOAT_EQ(cam.getFarClipPlane(), 1000.0f);
+}
+
+TEST_F(CameraTest, DefaultOrthographicSize) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_FLOAT_EQ(cam.getOrthographicSize(), 5.0f);
+}
+
+TEST_F(CameraTest, DefaultDepth) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_EQ(cam.getDepth(), 0);
+}
+
+TEST_F(CameraTest, DefaultViewportRect) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    const auto& rect = cam.getViewportRect();
+    EXPECT_FLOAT_EQ(rect.x, 0.0f);
+    EXPECT_FLOAT_EQ(rect.y, 0.0f);
+    EXPECT_FLOAT_EQ(rect.width, 1.0f);
+    EXPECT_FLOAT_EQ(rect.height, 1.0f);
+}
+
+TEST_F(CameraTest, DefaultRendersToScreen) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_TRUE(cam.rendersToScreen());
+    EXPECT_EQ(cam.getTargetTexture(), nullptr);
+}
+
+// -- Setters --
+
+TEST_F(CameraTest, SetProjectionType) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setProjectionType(ProjectionType::Orthographic);
+    EXPECT_EQ(cam.getProjectionType(), ProjectionType::Orthographic);
+}
+
+TEST_F(CameraTest, SetFieldOfView) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setFieldOfView(90.0f);
+    EXPECT_FLOAT_EQ(cam.getFieldOfView(), 90.0f);
+}
+
+TEST_F(CameraTest, SetClipPlanes) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setNearClipPlane(0.5f);
+    cam.setFarClipPlane(500.0f);
+    EXPECT_FLOAT_EQ(cam.getNearClipPlane(), 0.5f);
+    EXPECT_FLOAT_EQ(cam.getFarClipPlane(), 500.0f);
+}
+
+TEST_F(CameraTest, SetOrthographicSize) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setOrthographicSize(10.0f);
+    EXPECT_FLOAT_EQ(cam.getOrthographicSize(), 10.0f);
+}
+
+TEST_F(CameraTest, SetBackgroundColor) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    glm::vec4 color(1.0f, 0.0f, 0.0f, 1.0f);
+    cam.setBackgroundColor(color);
+    EXPECT_EQ(cam.getBackgroundColor(), color);
+}
+
+TEST_F(CameraTest, SetDepth) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setDepth(5);
+    EXPECT_EQ(cam.getDepth(), 5);
+}
+
+TEST_F(CameraTest, SetViewportRect) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    ViewportRect rect{0.0f, 0.0f, 0.5f, 0.5f};
+    cam.setViewportRect(rect);
+    const auto& r = cam.getViewportRect();
+    EXPECT_FLOAT_EQ(r.x, 0.0f);
+    EXPECT_FLOAT_EQ(r.width, 0.5f);
+}
+
+TEST_F(CameraTest, SetTargetTexture) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    auto fakeTexture = std::make_shared<int>(42);
+    cam.setTargetTexture(fakeTexture);
+    EXPECT_FALSE(cam.rendersToScreen());
+    EXPECT_NE(cam.getTargetTexture(), nullptr);
+    cam.setTargetTexture(nullptr);
+    EXPECT_TRUE(cam.rendersToScreen());
+}
+
+// -- View matrix --
+
+TEST_F(CameraTest, ViewMatrix_IdentityAtOrigin) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    // Camera at origin with no rotation should produce identity view.
+    EXPECT_TRUE(mat4Eq(cam.getViewMatrix(), glm::mat4(1.0f)));
+}
+
+TEST_F(CameraTest, ViewMatrix_TranslatedCamera) {
+    auto entity = scene->createEntity(glm::vec3(0.0f, 0.0f, 5.0f));
+    auto& cam = entity->addComponent<Camera>();
+    glm::mat4 view = cam.getViewMatrix();
+    // A camera at (0,0,5) should translate world by (0,0,-5).
+    glm::vec4 worldOrigin = view * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    EXPECT_TRUE(vec3Eq(glm::vec3(worldOrigin), glm::vec3(0.0f, 0.0f, -5.0f)));
+}
+
+TEST_F(CameraTest, ViewMatrix_IsInverseOfWorldTransform) {
+    auto entity = scene->createEntity(glm::vec3(1.0f, 2.0f, 3.0f), glm::vec3(10.0f, 20.0f, 0.0f));
+    auto& cam = entity->addComponent<Camera>();
+    auto* transform = entity->getComponent<Transform>();
+    glm::mat4 view = cam.getViewMatrix();
+    glm::mat4 world = transform->localToWorldMatrix();
+    EXPECT_TRUE(mat4Eq(view * world, glm::mat4(1.0f)));
+}
+
+// -- Projection matrix --
+
+TEST_F(CameraTest, PerspectiveProjection_ValidMatrix) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setFieldOfView(60.0f);
+    cam.setNearClipPlane(0.1f);
+    cam.setFarClipPlane(100.0f);
+    float aspect = 16.0f / 9.0f;
+    glm::mat4 proj = cam.getProjectionMatrix(aspect);
+    glm::mat4 expected = glm::perspectiveRH_ZO(glm::radians(60.0f), aspect, 0.1f, 100.0f);
+    expected[1][1] *= -1.0f;
+    EXPECT_TRUE(mat4Eq(proj, expected));
+}
+
+TEST_F(CameraTest, OrthographicProjection_ValidMatrix) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    cam.setProjectionType(ProjectionType::Orthographic);
+    cam.setOrthographicSize(5.0f);
+    cam.setNearClipPlane(0.1f);
+    cam.setFarClipPlane(100.0f);
+    float aspect = 16.0f / 9.0f;
+    glm::mat4 proj = cam.getProjectionMatrix(aspect);
+    // Orthographic: expected from glm::ortho with Y flipped.
+    float halfW = 5.0f * aspect;
+    glm::mat4 expected = glm::orthoRH_ZO(-halfW, halfW, -5.0f, 5.0f, 0.1f, 100.0f);
+    expected[1][1] *= -1.0f;
+    EXPECT_TRUE(mat4Eq(proj, expected));
+}
+
+// -- View-projection --
+
+TEST_F(CameraTest, ViewProjectionMatrix_IsProjTimesView) {
+    auto entity = scene->createEntity(glm::vec3(0.0f, 5.0f, 10.0f), glm::vec3(30.0f, 0.0f, 0.0f));
+    auto& cam = entity->addComponent<Camera>();
+    float aspect = 1.5f;
+    glm::mat4 vp = cam.getViewProjectionMatrix(aspect);
+    glm::mat4 expected = cam.getProjectionMatrix(aspect) * cam.getViewMatrix();
+    EXPECT_TRUE(mat4Eq(vp, expected));
+}
+
+// -- getMain --
+
+TEST_F(CameraTest, GetMain_ReturnsNullWhenNoCamera) {
+    scene->createEntity();
+    EXPECT_EQ(Camera::getMain(*scene), nullptr);
+}
+
+TEST_F(CameraTest, GetMain_ReturnsSingleCamera) {
+    auto entity = scene->createEntity();
+    auto& cam = entity->addComponent<Camera>();
+    EXPECT_EQ(Camera::getMain(*scene), &cam);
+}
+
+TEST_F(CameraTest, GetMain_ReturnsLowestDepth) {
+    auto e1 = scene->createEntity();
+    auto& cam1 = e1->addComponent<Camera>();
+    cam1.setDepth(10);
+    auto e2 = scene->createEntity();
+    auto& cam2 = e2->addComponent<Camera>();
+    cam2.setDepth(1);
+    auto e3 = scene->createEntity();
+    auto& cam3 = e3->addComponent<Camera>();
+    cam3.setDepth(5);
+    EXPECT_EQ(Camera::getMain(*scene), &cam2);
+}
+
+TEST_F(CameraTest, GetMain_SkipsDisabledCamera) {
+    auto e1 = scene->createEntity();
+    auto& cam1 = e1->addComponent<Camera>();
+    cam1.setDepth(0);
+    cam1.setEnabled(false);
+    auto e2 = scene->createEntity();
+    auto& cam2 = e2->addComponent<Camera>();
+    cam2.setDepth(5);
+    EXPECT_EQ(Camera::getMain(*scene), &cam2);
+}
+
+TEST_F(CameraTest, GetMain_SkipsInactiveEntity) {
+    auto e1 = scene->createEntity();
+    auto& cam1 = e1->addComponent<Camera>();
+    cam1.setDepth(0);
+    e1->setActive(false);
+    auto e2 = scene->createEntity();
+    auto& cam2 = e2->addComponent<Camera>();
+    cam2.setDepth(5);
+    EXPECT_EQ(Camera::getMain(*scene), &cam2);
+}
+
+TEST_F(CameraTest, GetMain_FindsCameraInChildEntity) {
+    auto parent = scene->createEntity();
+    auto child = scene->createEntity();
+    parent->addChild(child.get());
+    auto& cam = child->addComponent<Camera>();
+    EXPECT_EQ(Camera::getMain(*scene), &cam);
+}

--- a/vroom_editor/src/main.cpp
+++ b/vroom_editor/src/main.cpp
@@ -1,4 +1,5 @@
 #include <vroom/core/Engine.hpp>
+#include <vroom/components/Camera.hpp>
 #include <vroom/components/MeshRenderer.hpp>
 #include <vroom/components/MeshFilter.hpp>
 #include <vroom/components/Transform.hpp>
@@ -7,7 +8,6 @@
 #include <vroom/asset/AssetManager.hpp>
 #include <vroom/asset/AssetProvider.hpp>
 #include <glm/glm.hpp>
-#include <iostream>
 #include <vroom/logging/LogMacros.hpp>
 #ifdef VROOM_WITH_IMGUI
 #include <imgui.h>
@@ -15,15 +15,19 @@
 
 int main()
 {
-    // Use default config (headless=false)
     vroom::Engine engine;
-    // Configure asset manager with disk provider
     engine.getAssetManager().addProvider(std::make_unique<vroom::DiskAssetProvider>("vroom_editor/assets"));
-    // Create editor scene
     auto editorScene = std::make_shared<vroom::Scene>();
     editorScene->setSceneManager(&engine.getSceneManager());
+    // Camera entity positioned behind and slightly above the origin, looking forward.
+    auto cameraEntity = editorScene->createEntity(glm::vec3(0.0f, 1.0f, 5.0f));
+    auto& camera = cameraEntity->addComponent<vroom::Camera>();
+    camera.setFieldOfView(60.0f);
+    camera.setNearClipPlane(0.1f);
+    camera.setFarClipPlane(1000.0f);
+    // Mesh entity at the origin.
     auto editorEntity = editorScene->createEntity(glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.5f, 0.5f, 0.5f));
-    auto &meshFilter = editorEntity->addComponent<vroom::MeshFilter>();
+    auto& meshFilter = editorEntity->addComponent<vroom::MeshFilter>();
     auto mesh = engine.getAssetManager().getAsset<vroom::Mesh>("suzanne.obj");
     if (mesh)
     {
@@ -36,13 +40,13 @@ int main()
     {
         LOG_ERROR("Main", "Failed to load suzanne.obj");
     }
-    auto &meshRenderer = editorEntity->addComponent<vroom::MeshRenderer>();
+    auto& meshRenderer = editorEntity->addComponent<vroom::MeshRenderer>();
     auto defaultMaterial = std::make_shared<vroom::Material>();
     defaultMaterial->setColor(glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
     meshRenderer.setMaterial(defaultMaterial);
     engine.getSceneManager().loadScene(editorScene);
 #ifdef VROOM_WITH_IMGUI
-    engine.setImGuiCallback([&editorEntity]() {
+    engine.setImGuiCallback([&editorEntity, &cameraEntity]() {
         ImGui::Begin("Transform");
         auto* transform = editorEntity->getComponent<vroom::Transform>();
         if (transform) {
@@ -57,9 +61,41 @@ int main()
                 transform->setScale(scale);
         }
         ImGui::End();
+        ImGui::Begin("Camera");
+        auto* camTransform = cameraEntity->getComponent<vroom::Transform>();
+        auto* cam = cameraEntity->getComponent<vroom::Camera>();
+        if (camTransform) {
+            glm::vec3 pos = camTransform->getPosition();
+            glm::vec3 rot = camTransform->getRotation();
+            if (ImGui::DragFloat3("Position##cam", &pos.x, 0.05f))
+                camTransform->setPosition(pos);
+            if (ImGui::DragFloat3("Rotation##cam", &rot.x, 1.0f))
+                camTransform->setRotation(rot);
+        }
+        if (cam) {
+            float fov = cam->getFieldOfView();
+            float nearPlane = cam->getNearClipPlane();
+            float farPlane = cam->getFarClipPlane();
+            int projType = static_cast<int>(cam->getProjectionType());
+            const char* projItems[] = { "Perspective", "Orthographic" };
+            if (ImGui::Combo("Projection", &projType, projItems, 2))
+                cam->setProjectionType(static_cast<vroom::ProjectionType>(projType));
+            if (cam->getProjectionType() == vroom::ProjectionType::Perspective) {
+                if (ImGui::DragFloat("Field of View", &fov, 0.5f, 1.0f, 179.0f))
+                    cam->setFieldOfView(fov);
+            } else {
+                float orthoSize = cam->getOrthographicSize();
+                if (ImGui::DragFloat("Ortho Size", &orthoSize, 0.1f, 0.1f, 100.0f))
+                    cam->setOrthographicSize(orthoSize);
+            }
+            if (ImGui::DragFloat("Near Clip", &nearPlane, 0.01f, 0.001f, farPlane - 0.001f))
+                cam->setNearClipPlane(nearPlane);
+            if (ImGui::DragFloat("Far Clip", &farPlane, 1.0f, nearPlane + 0.001f, 100000.0f))
+                cam->setFarClipPlane(farPlane);
+        }
+        ImGui::End();
     });
 #endif
-    // Run engine
     engine.run();
     return 0;
 }


### PR DESCRIPTION
Closes #5

## Summary

- Introduces a Unity-style `Camera` component that computes view and projection matrices from its entity's `Transform`, replacing the hardcoded shader camera
- Adds a `Camera` inspector panel to the editor with position, rotation, FOV, projection type (perspective/orthographic), and clip plane controls
- Fixes depth buffering by switching to `perspectiveRH_ZO` / `orthoRH_ZO` for Vulkan's `[0,1]` depth range, and removes the OBJ loader's Y-negation hack in favour of a proper projection Y-flip

## Changes

- **`Camera` component** — perspective/orthographic projection, FOV, clip planes, background color, depth priority, viewport rect, `targetTexture` placeholder for future RenderTexture support, `Camera::getMain()` scene search
- **Vertex shader** — accepts `viewProjection` + `model` push constants (128 bytes total) instead of hardcoded matrices
- **`VulkanRenderer`** — resolves the active camera each frame via `Camera::getMain()` and pushes the VP matrix before scene draw
- **`MeshRenderer`** — pushes model matrix at byte offset 64 (after VP)
- **`ObjLoader`** — removes the `pos.y = -pos.y` hack; coordinate convention is now handled cleanly at the projection level
- **27 unit tests** covering defaults, setters, view/projection matrix correctness, and `getMain()` scene search behaviour

## Test plan

- [ ] `core_tests` passes (`Camera*` suite: 27/27)
- [ ] Editor builds and runs — monkey visible, correctly oriented, depth sorting correct
- [ ] Camera position and rotation controls move the view intuitively (increasing Y moves up)
- [ ] FOV, clip planes, and projection type toggle work in the Camera inspector panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)